### PR TITLE
replace "Upgrade: WebSocket" with "Upgrade: websocket"

### DIFF
--- a/WebSocket.cs
+++ b/WebSocket.cs
@@ -487,7 +487,7 @@ namespace net.vieapps.Components.WebSockets
 					var handshake =
 						$"HTTP/1.1 101 Switching Protocols\r\n" +
 						$"Connection: Upgrade\r\n" +
-						$"Upgrade: WebSocket\r\n" +
+						$"Upgrade: websocket\r\n" +
 						$"Server: {WebSocketHelper.AgentName}\r\n" +
 						$"Date: {DateTime.Now.ToHttpString()}\r\n" +
 						$"Sec-WebSocket-Accept: {requestKey.ComputeAcceptKey()}\r\n";
@@ -653,7 +653,7 @@ namespace net.vieapps.Components.WebSockets
 					$"Host: {uri.Host}:{uri.Port}\r\n" +
 					$"Origin: {uri.Scheme.Replace("ws", "http")}://{uri.Host}{(uri.Port != 80 && uri.Port != 443 ? $":{uri.Port}" : "")}\r\n" +
 					$"Connection: Upgrade\r\n" +
-					$"Upgrade: WebSocket\r\n" +
+					$"Upgrade: websocket\r\n" +
 					$"User-Agent: Mozilla/5.0 ({WebSocketHelper.AgentName}/{RuntimeInformation.FrameworkDescription.Trim()}/{(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "Macintosh; Intel Mac OS X; " : "")}{RuntimeInformation.OSDescription.Trim()})\r\n" +
 					$"Date: {DateTime.Now.ToHttpString()}\r\n" +
 					$"Sec-WebSocket-Version: 13\r\n" +


### PR DESCRIPTION
while most websocket servers implement RFC6455 correctly, a number of custom implementations do not respect section 4.2.1's case insensitivity requirements. 
this commit replaces usage of "Upgrade: WebSocket" with "Upgrade: websocket" as used in all examples in RFC6455 (see eg. https://tools.ietf.org/html/rfc6455#section-1.3) so that these custom websocket server implementations will also work with this client library.